### PR TITLE
Improvements to the Python implementation (command-line tool)

### DIFF
--- a/Readme
+++ b/Readme
@@ -26,6 +26,11 @@ Elixir implemenation: Converts binaries to proquint encoded strings,
 Decodes proquint encode strings to binaries. Implementation can be found
 at https://hexdocs.pm/proquint/Proquint.html
 
+Python implementation: converts between proquint, hex, decimal and
+IPv4 address strings. Installs a script 'proquint', which can be used
+to convert between above representations via command line
+(see python/README.md)
+
 Run "make clean all check" to build and check everything.  After that
 you can run "make demo" for a simple demo and "make examples" for more
 examples.

--- a/python/README.md
+++ b/python/README.md
@@ -18,3 +18,52 @@ pip install proquint
 lusab-babad
 ```
 
+### Command-line tool
+
+The package also installs a script `proquint` to do the conversion via command line:
+
+```
+usage: proquint [-h] [-n] [-x] [-i] [val]
+
+Convert between [integer, hexadecimal, IPv4 address] <-> proquint
+representations. See https://arxiv.org/html/0901.4016
+
+positional arguments:
+  val         value to convert (if not specified, IP address of the current
+              host is printed)
+
+optional arguments:
+  -h, --help  show this help message and exit
+  -n, --uint  convert from proquint to 32-bit integer
+  -x, --hex   convert from proquint to hexadecimal
+  -i, --ip    convert from proquint to IPv4
+```
+
+Examples:
+
+```bash
+$ proquint
+safom-bador
+
+$ proquint safom-bador
+3232235627
+
+$ proquint safom-bador -x
+0xc0a8006b
+
+$ proquint safom-bador -n
+3232235627
+
+$ proquint safom-bador -i
+192.168.0.107
+
+$ proquint 127.0.0.1
+lusab-babad
+
+$ proquint 0xffffffff
+zuzuz-zuzuz
+
+$ proquint 12345678
+bafus-kajav
+
+```

--- a/python/proquint/__init__.py
+++ b/python/proquint/__init__.py
@@ -1,1 +1,2 @@
 from .proquint import quint2uint, uint2quint
+from .utils import *

--- a/python/proquint/__main__.py
+++ b/python/proquint/__main__.py
@@ -1,0 +1,42 @@
+import argparse
+from utils import get_my_ip, convert
+
+
+def main():
+    desc = 'Convert between [integer, hexadecimal, IPv4 address] <-> proquint representations. '\
+        'See https://arxiv.org/html/0901.4016'
+
+    parser = argparse.ArgumentParser(description=desc)
+    parser.add_argument('-n', '--uint', action='store_true',
+                        help='convert from proquint to 32-bit integer', required=False)
+    parser.add_argument('-x', '--hex', action='store_true',
+                        help='convert from proquint to hexadecimal', required=False)
+    parser.add_argument('-i', '--ip', action='store_true',
+                        help='convert from proquint to IPv4', required=False)
+    parser.add_argument('val', nargs='?', type=str, default=None,
+                        help='value to convert (if not specified, ' \
+                        'IP address of the current host is printed)')
+
+    args = parser.parse_args()
+
+    target = None
+    if args.uint:
+        target = 'uint'
+    elif args.hex:
+        target = 'hex'
+    elif args.ip:
+        target = 'ip'
+
+    try:
+        if args.val is None:
+            res = convert(get_my_ip())
+        else:
+            res = convert(args.val, target)
+    except ValueError as e:
+        print('{}'.format(str(e)))
+    else:
+        print('{}'.format(res))
+
+
+if __name__ == "__main__":
+    main()

--- a/python/proquint/proquint.py
+++ b/python/proquint/proquint.py
@@ -52,8 +52,12 @@ def quint2uint(quint):
     :param quint: proquint string identifier to decode
     :return: 32-bit integer representation of the proquint encoded value
     """
+    nchar = len(quint)
+    if nchar < 10 or nchar > 11:
+        raise ValueError('Proquint should be in form of two quintets + optional separator')
+
     res = 0
-    for c in quint:
+    for i, c in enumerate(quint):
         mag = CONSONANT_TO_UINT.get(c)
         if mag is not None:
             res <<= 4
@@ -63,4 +67,6 @@ def quint2uint(quint):
             if mag is not None:
                 res <<= 2
                 res += mag
+            elif i != 5:
+                raise ValueError('Bad proquint format')
     return res

--- a/python/proquint/utils.py
+++ b/python/proquint/utils.py
@@ -1,0 +1,102 @@
+import socket
+from proquint import quint2uint, uint2quint
+
+
+def get_my_ip():
+    """Return the external IPv4 address of the current host, otherwise 127.0.0.1"""
+    try:
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        s.connect(('8.8.8.8', 80))
+        ip_addr = s.getsockname()[0]
+        s.close()
+        return ip_addr
+    except OSError:
+        return '127.0.0.1'
+
+
+def ip2uint_str(ipv4_str):
+    """Convert IPv4 string to 32-bit integer value"""
+    parts = ipv4_str.split('.')
+    if len(parts) != 4:
+        raise ValueError('Expected IPv4 address in form A.B.C.D, got {}'.
+                         format(ipv4_str))
+    ip = [0]*4
+    for i, part in enumerate(parts):
+        try:
+            int_part = int(part)
+        except ValueError:
+            raise ValueError('Part {} of IPv4 address is not an integer'.
+                             format(i))
+        if int_part < 0 or int_part > 255:
+            raise ValueError('Part {} of IPv4 address is not in range 0-255'.
+                             format(i))
+        ip[i] = int_part
+    return (ip[0] << 24) + (ip[1] << 16) + (ip[2] << 8) + ip[3]
+
+
+def uint2ip_str(uint_val):
+    "Covert 32-bit integer value to IPv4 string"
+    return '{}.{}.{}.{}'.format(
+        (uint_val >> 24)&0xFF,
+        (uint_val >> 16)&0xFF,
+        (uint_val >> 8)&0xFF,
+        uint_val&0xFF)
+
+
+def uint2quint_str(uint_str, separator='-'):
+    return uint2quint(int(uint_str), separator)
+
+
+def quint2uint_str(quint):
+    return str(quint2uint(quint))
+
+
+def hex2quint_str(hex_str, separator='-'):
+    return uint2quint(int(hex_str, 16), separator)
+
+
+def quint2hex_str(quint):
+    return hex(quint2uint(quint))
+
+
+def convert(str_val, target=None):
+    """Convert between proquint, integer, hex or IPv4 string representations.
+    Tries to guess the representation from input.
+
+    :param str_val: input representation (string)
+    :return: output representation (string)
+    """
+    if target is not None and target not in {'uint', 'hex', 'ip'}:
+        raise ValueError('Convert target should be one of: uint, hex, ip')
+
+    if target == 'uint':
+        return quint2uint_str(str_val)
+
+    if target == 'hex':
+        return quint2hex_str(str_val)
+
+    if target == 'ip':
+        return uint2ip_str(quint2uint(str_val))
+
+    # try to guess the representation
+    try:
+        return quint2uint_str(str_val)
+    except ValueError:
+        pass
+
+    try:
+        return uint2quint_str(str_val)
+    except ValueError:
+        pass
+
+    try:
+        return hex2quint_str(str_val)
+    except ValueError:
+        pass
+
+    try:
+        return uint2quint_str(ip2uint_str(str_val))
+    except ValueError:
+        pass
+
+    raise ValueError('Unrecognized input format: {}'.format(str_val))

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-__version__ = '0.1.0'
+__version__ = '0.2.0'
 
 tests_require = [
     'nose >= 1.3',
@@ -19,4 +19,9 @@ setup(
     classifiers = [],
     tests_require=tests_require,
     test_suite="nose.collector",
+    entry_points = {
+        'console_scripts': [
+            'proquint = proquint.__main__:main'
+        ],
+    }
 )

--- a/python/tests/test_encoding.py
+++ b/python/tests/test_encoding.py
@@ -1,6 +1,6 @@
-from nose.tools import assert_list_equal, assert_equals, assert_not_equals
+from nose.tools import assert_list_equal, assert_equals, assert_not_equals, assert_raises
 from hypothesis import given, strategies as st
-from proquint import uint2quint, quint2uint
+from proquint import uint2quint, quint2uint, ip2uint_str, uint2ip_str, convert
 
 
 @given(st.integers(0, 0xFFFFFFFF), st.sampled_from('- |.'))
@@ -13,27 +13,64 @@ def test_encoding(uint_val, separator):
     assert_equals(uint_val, uint_val1)
 
 
-def ip2int(ip):
-    return (ip[0] << 24) + (ip[1] << 16) + (ip[2] << 8) + ip[3]
-
-
 def test_presets():
     presets = [
-        ([127,0,0,1],       'lusab-babad'),
-        ([63,84,220,193],   'gutih-tugad'),
-        ([63,118,7,35],     'gutuk-bisog'),
-        ([140,98,193,141],  'mudof-sakat'),
-        ([64,255,6,200],    'haguz-biram'),
-        ([128,30,52,45],    'mabiv-gibot'),
-        ([147,67,119,2],    'natag-lisaf'),
-        ([212,58,253,68],   'tibup-zujah'),
-        ([216,35,68,215],   'tobog-higil'),
-        ([216,68,232,21],   'todah-vobij'),
-        ([198,81,129,136],  'sinid-makam'),
-        ([12,110,110,204],  'budov-kuras')]
+        ('127.0.0.1',       'lusab-babad'),
+        ('63.84.220.193',   'gutih-tugad'),
+        ('63.118.7.35',     'gutuk-bisog'),
+        ('140.98.193.141',  'mudof-sakat'),
+        ('64.255.6.200',    'haguz-biram'),
+        ('128.30.52.45',    'mabiv-gibot'),
+        ('147.67.119.2',    'natag-lisaf'),
+        ('212.58.253.68',   'tibup-zujah'),
+        ('216.35.68.215',   'tobog-higil'),
+        ('216.68.232.21',   'todah-vobij'),
+        ('198.81.129.136',  'sinid-makam'),
+        ('12.110.110.204',  'budov-kuras')]
 
-    quints = [uint2quint(ip2int(t[0])) for t in presets]
+    quints = [uint2quint(ip2uint_str(t[0])) for t in presets]
     assert_list_equal(quints, [t[1] for t in presets])
 
     uints = [quint2uint(t[1]) for t in presets]
-    assert_list_equal(uints, [ip2int(t[0]) for t in presets])
+    assert_list_equal(uints, [ip2uint_str(t[0]) for t in presets])
+
+
+def test_incorrect_input():
+    with assert_raises(ValueError):
+        quint2uint('foo-barr')
+
+    with assert_raises(ValueError):
+        quint2uint('')
+
+    with assert_raises(ValueError):
+        quint2uint('1234')
+
+    with assert_raises(ValueError):
+        quint2uint('foo')
+
+    with assert_raises(ValueError):
+        quint2uint('xxxx-yyyy')
+
+    with assert_raises(TypeError):
+        quint2uint(42)
+
+
+@given(st.integers(0, 0xFFFFFFFF))
+def test_ipv4_conversion(uint_val):
+    ip = uint2ip_str(uint_val)
+    assert_equals(4, len(ip.split('.')))
+    assert_equals(uint_val, ip2uint_str(ip))
+
+    assert_equals(0xFF00FF01, ip2uint_str('255.0.255.1'))
+    assert_equals('255.0.255.1', uint2ip_str(0xFF00FF01))
+
+
+def test_convert():
+    assert_equals('2130706433', convert('lusab-babad'))
+    assert_equals('2130706433', convert('lusab-babad', 'uint'))
+    assert_equals('0x7f000001', convert('lusab-babad', 'hex'))
+    assert_equals('127.0.0.1', convert('lusab-babad', 'ip'))
+
+    assert_equals('lusab-babad', convert('127.0.0.1'))
+    assert_equals('lusab-babad', convert('2130706433'))
+    assert_equals('lusab-babad', convert('0x7f000001'))


### PR DESCRIPTION
I've made some improvements to the Python implementation:

*  added conversion from/to IPv4 and hex strings
*  the input data is validated for being of correct format
*  changed the root Readme, adding more info about the Python implementation
*  the package now includes a command-line tool, `proquint`, which allows to do all the back and forth conversions from e.g. bash:
```bash
$ proquint 127.0.0.1
lusab-babad
```
