### PR TITLE
Tried to make the java example a bit more java-style

### DIFF
--- a/Proquint.java
+++ b/Proquint.java
@@ -1,13 +1,14 @@
 /* This file is part of proquint: http://github.com/dsw/proquint .
-   See License.txt for copyright and terms of use. */
+ * See License.txt for copyright and terms of use. 
+ */
 
 import java.io.*;
 
 /**
-  Convert between proquint, hex, and decimal strings.
-  Please see the article on proquints: http://arXiv.org/html/0901.4016
-  Daniel S. Wilkerson
-*/
+ * Convert between proquint, hex, and decimal strings.
+ * Please see the article on proquints: http://arXiv.org/html/0901.4016
+ * Daniel S. Wilkerson
+ */
 public class Proquint {
 
   /** Map uints to consonants. */
@@ -24,78 +25,82 @@ public class Proquint {
   };
 
   /** Convert an unsigned int to a proquint; the output is appended to
-   * quint; sepChar will be omitted if -1. */
-  static void uint2quint
-    (StringBuffer quint /*output*/, int i, char sepChar)
+   * quint; sepChar will be omitted if -1. 
+   */
+  static String uint2quint(int i, String sepChar)
   {
     // http://docs.oracle.com/javase/tutorial/java/nutsandbolts/opsummary.html
     // ">>>" Unsigned right shift
-    int j;
+		StringBuffer quint = new StringBuffer();
 
-    final int MASK_FIRST4 = 0xF0000000;
-    final int MASK_FIRST2 = 0xC0000000;
+		quint.append(uint2consonant[i >>> 28]);
+		i <<= 4;
+		quint.append(uint2vowel[i >>> 30]);
+		i <<= 2;
+		quint.append(uint2consonant[i >>> 28]);
+		i <<= 4;
+		quint.append(uint2vowel[i >>> 30]);
+		i <<= 2;
+		quint.append(uint2consonant[i >>> 28]);
+		i <<= 4;
 
-    j = i & MASK_FIRST4; i <<= 4; j >>>= 28; quint.append(uint2consonant[j]);
-    j = i & MASK_FIRST2; i <<= 2; j >>>= 30; quint.append(uint2vowel[j]);
-    j = i & MASK_FIRST4; i <<= 4; j >>>= 28; quint.append(uint2consonant[j]);
-    j = i & MASK_FIRST2; i <<= 2; j >>>= 30; quint.append(uint2vowel[j]);
-    j = i & MASK_FIRST4; i <<= 4; j >>>= 28; quint.append(uint2consonant[j]);
+		quint.append(sepChar);
 
-    if (sepChar != -1) {
-      quint.append(((char) sepChar));
-    }
+		quint.append(uint2consonant[i >>> 28]);
+		i <<= 4;
+		quint.append(uint2vowel[i >>> 30]);
+		i <<= 2;
+		quint.append(uint2consonant[i >>> 28]);
+		i <<= 4;
+		quint.append(uint2vowel[i >>> 30]);
+		i <<= 2;
+		quint.append(uint2consonant[i >>> 28]);
+		i <<= 4;
 
-    j = i & MASK_FIRST4; i <<= 4; j >>>= 28; quint.append(uint2consonant[j]);
-    j = i & MASK_FIRST2; i <<= 2; j >>>= 30; quint.append(uint2vowel[j]);
-    j = i & MASK_FIRST4; i <<= 4; j >>>= 28; quint.append(uint2consonant[j]);
-    j = i & MASK_FIRST2; i <<= 2; j >>>= 30; quint.append(uint2vowel[j]);
-    j = i & MASK_FIRST4; i <<= 4; j >>>= 28; quint.append(uint2consonant[j]);
+		return quint.toString();
   }
 
-  /** Convert a proquint to an unsigned int (long).
+  /** 
+   * Convert a proquint to an unsigned int (long).
    */
-  static long quint2uint(Reader quint) throws IOException {
-    long res = 0;
+	static long quint2uint(String quint) {
+		long res = 0;
 
-    while(true) {
-      final int c = quint.read();
-      if (c == -1) break;
-
+    for (char c : quint.toCharArray()) {
       switch(c) {
 
-        /* consonants */
-      case 'b': res <<= 4; res +=  0; break;
-      case 'd': res <<= 4; res +=  1; break;
-      case 'f': res <<= 4; res +=  2; break;
-      case 'g': res <<= 4; res +=  3; break;
+          /* consonants */
+        case 'b': res <<= 4; res +=  0; break;
+        case 'd': res <<= 4; res +=  1; break;
+        case 'f': res <<= 4; res +=  2; break;
+        case 'g': res <<= 4; res +=  3; break;
 
-      case 'h': res <<= 4; res +=  4; break;
-      case 'j': res <<= 4; res +=  5; break;
-      case 'k': res <<= 4; res +=  6; break;
-      case 'l': res <<= 4; res +=  7; break;
+        case 'h': res <<= 4; res +=  4; break;
+        case 'j': res <<= 4; res +=  5; break;
+        case 'k': res <<= 4; res +=  6; break;
+        case 'l': res <<= 4; res +=  7; break;
 
-      case 'm': res <<= 4; res +=  8; break;
-      case 'n': res <<= 4; res +=  9; break;
-      case 'p': res <<= 4; res += 10; break;
-      case 'r': res <<= 4; res += 11; break;
+        case 'm': res <<= 4; res +=  8; break;
+        case 'n': res <<= 4; res +=  9; break;
+        case 'p': res <<= 4; res += 10; break;
+        case 'r': res <<= 4; res += 11; break;
 
-      case 's': res <<= 4; res += 12; break;
-      case 't': res <<= 4; res += 13; break;
-      case 'v': res <<= 4; res += 14; break;
-      case 'z': res <<= 4; res += 15; break;
+        case 's': res <<= 4; res += 12; break;
+        case 't': res <<= 4; res += 13; break;
+        case 'v': res <<= 4; res += 14; break;
+        case 'z': res <<= 4; res += 15; break;
 
-        /* vowels */
-      case 'a': res <<= 2; res +=  0; break;
-      case 'i': res <<= 2; res +=  1; break;
-      case 'o': res <<= 2; res +=  2; break;
-      case 'u': res <<= 2; res +=  3; break;
+          /* vowels */
+        case 'a': res <<= 2; res +=  0; break;
+        case 'i': res <<= 2; res +=  1; break;
+        case 'o': res <<= 2; res +=  2; break;
+        case 'u': res <<= 2; res +=  3; break;
 
-        /* separators */
-      default: break;
+          /* separators */
+        default: break;
       }
-    }
-
-    return res;
   }
 
+		return res;
+	}
 }

--- a/ProquintMain.java
+++ b/ProquintMain.java
@@ -15,12 +15,10 @@ public class ProquintMain {
       C rather than use the Java libraries so the behavior would be
       the same).
   */
-  public static int my_atoi(int base, Reader s) throws IOException {
+  public static int my_atoi(int base, String s) throws IOException {
     long ret = 0;
 
-    while(true) {
-      final int c = s.read();
-      if (c == -1) break;
+    for (char c : s.toCharArray()) {
       int value = -1;
 
       switch(c) {
@@ -46,8 +44,7 @@ public class ProquintMain {
 
         /* illegal characters */
       default:
-        System.err.println("Illegal character in uint-word: '"+ (char) c+
-                           "'.");
+        System.err.println("Illegal character in uint-word: '"+ c + "'.");
         System.exit(1);
         break;
       }
@@ -59,7 +56,7 @@ public class ProquintMain {
       if (value >= base) {
         System.err.println
           ("Numbers of base "+ base+
-           " may not contain the digit '"+ (char) c+ "'.");
+           " may not contain the digit '"+ c + "'.");
         System.exit(1);
       }
 
@@ -79,29 +76,21 @@ public class ProquintMain {
     return (int) ret;
   }
 
-  public static void main_convertNumber(int base, Reader s)
-    throws IOException
-  {
-    /* Length of a 32-bit quint word, without trailing NUL:
-       two quints plus a separator. */
-    final int QUINT_LEN = 5*2 + 1;
-    /* Double length plus another separator in case we switch to
-       64-bits. */
-    final int DOUBLE_QUINT_LEN = 2*QUINT_LEN + 1;
+  public static void main_convertNumber(int base, String s)
+    throws IOException {
+    //my_atoi could be replaced with:
+    //final int n = Integer.parseUnsignedInt(s, base);
 
     // this seems to be the best place to chop the precision
     final int n = my_atoi(base, s);
-    StringBuffer quint = new StringBuffer(DOUBLE_QUINT_LEN+1);
-    Proquint.uint2quint(quint, n, '-');
+    String quint = Proquint.uint2quint(n, "-");
 
-    /* fprintf(stderr, "uint %s -> quint %s\n", s, quint); */
-    System.out.print(quint.toString()+ " ");
+    System.out.printf("uint %s -> quint %s\n", s, quint);
   }
 
-  public static void main_convertQuint(Reader s) throws IOException {
+  public static void main_convertQuint(String s) throws IOException {
     long uint0 = Proquint.quint2uint(s);
-    /* fprintf(stderr, "quint %s -> uint %u = x%x\n", s, uint0, uint0); */
-    System.out.print("x"+ Long.toHexString(uint0)+ " ");
+    System.out.printf("quint %s -> uint %d = x%x\n", s, uint0, uint0);
   }
 
   /* Convert command-line strings.
@@ -118,13 +107,13 @@ public class ProquintMain {
         System.exit(1);
       } else if (s0 == 'x' || s0 == 'X') {
         /* a hexadecimal number */
-        main_convertNumber(16, new StringReader(s.substring(1)));
+        main_convertNumber(16, s.substring(1));
       } else if (Character.isDigit(s0)) {
         /* a decimal number */
-        main_convertNumber(10, new StringReader(s));
+        main_convertNumber(10, s);
       } else {
         /* a quint word */
-        main_convertQuint(new StringReader(s));
+        main_convertQuint(s);
       }
     }
 


### PR DESCRIPTION
Inspired by #1 I tried to make the Java example a bit more "java-style". Is this something you would be interested incorporating?

The masking part of `uint2quint` seems to be superfluous to me, am I missing something? I removed it and only left the bit shift, and it seems to work.

The `my_atoi` could be replaced with `Integer.parseUnsignedInt`, I only added a comment about it, since I saw that you had kept it to keep in line with the c implementation. The current implementation only allows half of the value space since it checks against `Integer.MAX_VALUE`, switching to `parseUnsignedInt` would allow the full space to be used. I don't know if this is an intended limitation?

Anyway, thanks for a really novel idea! I'm sure it will make people's lives a bit less frustrating =)